### PR TITLE
Remove uses of reduce/spread which causes significant latency to large middlewares

### DIFF
--- a/src/applicator.ts
+++ b/src/applicator.ts
@@ -153,9 +153,9 @@ function applyMiddlewareToType<TSource, TContext, TArgs>(
     const resolvers = Object.keys(middleware).reduce(
       (resolvers, fieldName) => {
         resolvers[fieldName] = applyMiddlewareToField(
-          fieldMap[field],
+          fieldMap[fieldName],
           options,
-          middleware[field],
+          middleware[fieldName],
         );
         return resolvers;
       },
@@ -221,6 +221,7 @@ export function generateResolverFromSchemaAndMiddleware<
           options,
           middleware[type],
         );
+        return resolvers;
       },
       {},
     )

--- a/src/applicator.ts
+++ b/src/applicator.ts
@@ -45,11 +45,10 @@ function parseField(
 ) {
   const { isDeprecated, ...restData } = field
   const argsMap = field.args.reduce(
-    (acc, cur) => ({
-      ...acc,
-      [cur.name]: cur,
-    }),
-    {} as Record<string, GraphQLArgument>,
+    (acc, cur) => {
+      acc[cur.name] = cur;
+      return acc;
+    }, {} as Record<string, GraphQLArgument>,
   )
   return {
     ...restData,
@@ -138,28 +137,28 @@ function applyMiddlewareToType<TSource, TContext, TArgs>(
 
   if (isMiddlewareFunction(middleware)) {
     const resolvers = Object.keys(fieldMap).reduce(
-      (resolvers, fieldName) => ({
-        ...resolvers,
-        [fieldName]: applyMiddlewareToField(
+      (resolvers, fieldName) => {
+        resolvers[fieldName] = applyMiddlewareToField(
           fieldMap[fieldName],
           options,
           middleware as IMiddlewareFunction<TSource, TContext, TArgs>,
-        ),
-      }),
+        );
+        return resolvers;
+      },
       {},
     )
 
     return resolvers
   } else {
     const resolvers = Object.keys(middleware).reduce(
-      (resolvers, field) => ({
-        ...resolvers,
-        [field]: applyMiddlewareToField(
+      (resolvers, fieldName) => {
+        resolvers[fieldName] = applyMiddlewareToField(
           fieldMap[field],
           options,
           middleware[field],
-        ),
-      }),
+        );
+        return resolvers;
+      },
       {},
     )
 
@@ -181,14 +180,14 @@ function applyMiddlewareToSchema<TSource, TContext, TArgs>(
         !isIntrospectionType(typeMap[type]),
     )
     .reduce(
-      (resolvers, type) => ({
-        ...resolvers,
-        [type]: applyMiddlewareToType(
+      (resolvers, type) => {
+        resolvers[type] = applyMiddlewareToType(
           typeMap[type] as GraphQLObjectType,
           options,
           middleware,
-        ),
-      }),
+        );
+        return resolvers;
+      },
       {},
     )
 
@@ -216,14 +215,13 @@ export function generateResolverFromSchemaAndMiddleware<
     const typeMap = schema.getTypeMap()
 
     const resolvers = Object.keys(middleware).reduce(
-      (resolvers, type) => ({
-        ...resolvers,
-        [type]: applyMiddlewareToType(
+      (resolvers, type) => {
+        resolvers[type] = applyMiddlewareToType(
           typeMap[type] as GraphQLObjectType,
           options,
           middleware[type],
-        ),
-      }),
+        );
+      },
       {},
     )
 


### PR DESCRIPTION
Hi there, at work we have a very large graphql schema and use graphql middlewares heavily. I've recently been debugging why our graphql server takes so long to start up and identified one area in this library that contributes a good chunk of that time. 

I found that this library performs quite poorly when a particular middleware contains a lot (~1k+) of keys. After a deeper inspection, I see that applicator.ts uses the [reduce/spread anti-pattern](https://prateeksurana.me/blog/why-using-object-spread-with-reduce-bad-idea/) which I have been bitten by a few times in the last handful of years. The simple changes in this PR should not change the behavior of this library at all but they did reduce the total latency of our `applyMiddleware` call from ~11s to about 6s. If others in the community are using this library with large schemas & middlewares then I want them to benefit as well.

